### PR TITLE
enable DSL-1 so tutorial works on nextflow 22.04.0+

### DIFF
--- a/script2.nf
+++ b/script2.nf
@@ -1,3 +1,4 @@
+nextflow.enable.dsl = 1
 /* 
  * pipeline input parameters 
  */

--- a/script3.nf
+++ b/script3.nf
@@ -1,3 +1,4 @@
+nextflow.enable.dsl = 1
 /* 
  * pipeline input parameters 
  */

--- a/script4.nf
+++ b/script4.nf
@@ -1,3 +1,4 @@
+nextflow.enable.dsl = 1
 /* 
  * pipeline input parameters 
  */

--- a/script5.nf
+++ b/script5.nf
@@ -1,3 +1,4 @@
+nextflow.enable.dsl = 1
 /* 
  * pipeline input parameters 
  */

--- a/script6.nf
+++ b/script6.nf
@@ -1,3 +1,4 @@
+nextflow.enable.dsl = 1
 /* 
  * pipeline input parameters 
  */

--- a/script7.nf
+++ b/script7.nf
@@ -1,3 +1,5 @@
+nextflow.enable.dsl = 1
+
 /* 
  * pipeline input parameters 
  */


### PR DESCRIPTION
A better solution would be to rewrite the tutorial using DSL-2, but this at least allows a new user to execute the examples without immediately getting an error